### PR TITLE
Update dependencies

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 # Top level module
 module LoggingFactory
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/logging_factory.gemspec
+++ b/logging_factory.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rubocop', '~> 0.23.0'
   gem.add_development_dependency 'simplecov', '~> 0.6.4'
 
-  gem.add_dependency 'logging', '~> 1.8.1'
+  gem.add_dependency 'logging', '~> 2.0.0'
   gem.add_dependency 'preconditions', '~> 0.3.0'
 end

--- a/spec/log_stdout_spec.rb
+++ b/spec/log_stdout_spec.rb
@@ -13,7 +13,7 @@ describe LoggingFactory::Logger do
     let(:warn_message) { 'This is a warn message' }
     let(:error_message) { 'This is an error message' }
     let(:fatal_message) { 'This is a fatal message' }
-    let(:time_regex) { /\[\d{4}(\-\d{2}){2} \d{2}(\:\d{2}){2}\]/ }
+    let(:time_regex) { /\[\d{4}(\-\d{2}){2}T\d{2}(\:\d{2}){2}\]/ }
 
     before do
       log.debug(debug_message)


### PR DESCRIPTION
I'd like to update the Gemfile to allow for a more recent version of logging. Version 0.0.3's Gemfile was causing dependency conflicts with newer gems (googleauth 0.5.1, in this case, which requires logging 2.0)

I've also updated the unit test to account for the altered timestamp. The newer logging gem places a 'T' between the datestamp and timestamp.